### PR TITLE
UIMS-2 Use JS for Jest config instead of TS

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,8 @@
-import type { Config } from 'jest';
-import path from 'path';
-
+const path = require('path');
 const stripesConfig = require('@folio/jest-config-stripes');
 const acqConfig = require('@folio/stripes-acq-components/jest.config');
 
-const config: Config = {
+const config = {
   ...stripesConfig,
   collectCoverageFrom: [
     ...stripesConfig.collectCoverageFrom,
@@ -23,4 +21,4 @@ const config: Config = {
   ],
 };
 
-export default config;
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
     "formatjs-compile": "stripes translate compile",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\"",
-    "test": "jest --ci --coverage --config=jest.config.ts"
+    "test": "jest --ci --coverage"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/UIMS-2

There is an issue with compilation on platform level. Platform dependencies should have `@types/jest` to fix TS error, but alternatively it makes sense to use JS for such configuration.

![image](https://github.com/user-attachments/assets/8b864b33-ed24-4369-9a84-be5b0c5a146e)
